### PR TITLE
parsing_2: add `LogLine.__str__`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ parsing_log_1
 frequency.csv
 frequqncy.xlsx
 venv
+__pycache__

--- a/parsing_2.py
+++ b/parsing_2.py
@@ -35,6 +35,16 @@ class LogLine:
         log_matches = re.finditer(APACHE_LOG_REGEX, log_contents, re.MULTILINE)
         return [LogLine(log_match) for log_match in log_matches]
 
+    def __str__(self):
+        # `self.identity` is optional; if it exists, there must be a space before it
+        identity = ""
+        if self.identity:
+            identity = " " + self.identity
+
+        # Need to write the date in the Apache format instead of this program's usual format
+        date = self.date.strftime(APACHE_LOG_DATE_FORMAT)
+        return f"{self.hostname}{identity} {self.user_id} [{date}] \"{self.request}\" {self.status_code} {self.response_size}"
+
 def main():
     file_contents = ""
 


### PR DESCRIPTION
This allows `LogLine` to be converted to a string. Since this will be used when splitting the log file, I've stuck to the Apache log file format.